### PR TITLE
Disabling IPv6 for port 80

### DIFF
--- a/conf/default.conf
+++ b/conf/default.conf
@@ -1,6 +1,6 @@
 server {
   listen 80;
-  listen [::]:80;
+  #listen [::]:80;
 
   root /var/www/site;
   index index.html;


### PR DESCRIPTION
Fixing the error

2020/12/23 23:04:11 [emerg] 1#1: socket() [::]:80 failed (97: Address family not supported by protocol)
nginx: [emerg] socket() [::]:80 failed (97: Address family not supported by protocol)
